### PR TITLE
Added a fallback option if no hash is given, but hash has changed.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-stickytabs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://github.com/aidanlister/jquery-stickytabs",
   "authors": [
     "Aidan Lister <aidan@aidanlister.com>"

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -6,11 +6,11 @@
  */
 (function ( $ ) {
     $.fn.stickyTabs = function( options ) {
-        var context = this
+        var context = this;
 
         var settings = $.extend({
             getHashCallback: function(hash, btn) { return hash },
-            fallbackHash: ''
+            defaultHash: '',
         }, options );
 
         // Show the tab corresponding with the hash in the URL, or the first tab.
@@ -21,16 +21,19 @@
         }
 
         var getFallbackHash = function() {
-            if(settings.fallbackHash != '')
+
+            if(settings.defaultHash != '')
             {
-                return 'a[href="' + settings.fallbackHash + '"]';
+                return 'a[href="#' + settings.defaultHash + '"]';
             }
 
             return 'li.active > a';
         }
 
+        settings.defaultHash = $("li.active > a", context).prop("href").split('#')[1];
+
         // Set the correct tab when the page loads
-        showTabFromHash(context)
+        showTabFromHash(context);
 
         // Set the correct tab when a user uses their back/forward button
         $(window).on('hashchange', showTabFromHash);

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -2,21 +2,31 @@
  * jQuery Plugin: Sticky Tabs
  *
  * @author Aidan Lister <aidan@php.net>
- * @version 1.0.1
+ * @version 1.1.2
  */
 (function ( $ ) {
     $.fn.stickyTabs = function( options ) {
         var context = this
 
         var settings = $.extend({
-            getHashCallback: function(hash, btn) { return hash }
+            getHashCallback: function(hash, btn) { return hash },
+            fallbackHash: ''
         }, options );
 
         // Show the tab corresponding with the hash in the URL, or the first tab.
         var showTabFromHash = function() {
           var hash = window.location.hash;
-          var selector = hash ? 'a[href="' + hash + '"]' : 'li.active > a';
+          var selector = hash ? 'a[href="' + hash + '"]' : getFallbackHash();
           $(selector, context).tab('show');
+        }
+
+        var getFallbackHash = function() {
+            if(settings.fallbackHash != '')
+            {
+                return 'a[href="' + settings.fallbackHash + '"]';
+            }
+
+            return 'li.active > a';
         }
 
         // Set the correct tab when the page loads

--- a/tests/defaultTab.html
+++ b/tests/defaultTab.html
@@ -9,9 +9,7 @@
     <script src="../jquery.stickytabs.js"></script>
     <script>
     $(function() {
-        $('.nav-tabs-sticky').stickyTabs({
-          fallbackHash: '#home'
-        });
+        $('.nav-tabs-sticky').stickyTabs();
     });
     </script>
   </head>

--- a/tests/fallback.html
+++ b/tests/fallback.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+  <head>
+    <meta charset="utf-8">
+    <title>Testing jQuery.stickytabs.js</title>
+    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/css/bootstrap.css">
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.js"></script>
+    <script src="../jquery.stickytabs.js"></script>
+    <script>
+    $(function() {
+        $('.nav-tabs-sticky').stickyTabs({
+          fallbackHash: '#home'
+        });
+    });
+    </script>
+  </head>
+  <body>
+  <div class="container">
+
+    <div class="col-sm-6">
+      <div role="tabpanel">
+
+        <!-- Nav tabs -->
+        <ul class="nav nav-tabs nav-tabs-sticky" role="tablist">
+          <li role="presentation" class="active"><a href="#home" aria-controls="home" role="tab" data-toggle="tab">Home</a></li>
+          <li role="presentation"><a href="#profile" aria-controls="profile" role="tab" data-toggle="tab">Profile</a></li>
+          <li role="presentation"><a href="#messages" aria-controls="messages" role="tab" data-toggle="tab">Messages</a></li>
+          <li role="presentation"><a href="#settings" aria-controls="settings" role="tab" data-toggle="tab">Settings</a></li>
+        </ul>
+
+        <!-- Tab panes -->
+        <div class="tab-content">
+          <div role="tabpanel" class="tab-pane active" id="home">Home</div>
+          <div role="tabpanel" class="tab-pane" id="profile">Profile</div>
+          <div role="tabpanel" class="tab-pane" id="messages">Messages</div>
+          <div role="tabpanel" class="tab-pane" id="settings">Settings</div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="col-sm-6">
+      <p>Tests:</p>
+      <ol>
+        <li><a href="#settings">Tab change</a>: Should show "Settings" and the Settings tab should be active.</li>
+        <li><a href="#home">First tab</a>: Should show "Home" and the Home tab should be active.</li>
+        <li><a onclick="window.history.go(-1)">Back button</a>: Should go back to the settings tab.</li>
+        <li><a onclick="window.history.go(-1)">Back button</a>: Should go back to the home tab.</li>
+      </ol>
+    </div>
+
+  </div>
+  </body>
+</html>


### PR DESCRIPTION
Hi,

I needed a fallback if the user hits the back button and the hash changes to nothing.
So now it's simply possible to call stickyTabs like this:

``` js
$('.nav-tabs-sticky').stickyTabs({
    fallbackHash: '#home'
});
```

I also increased the version number and added a simple test.
