### PR TITLE
Initial support for using Composer package manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     }
   },
   "require": {
-    "robloach/component-installer": "*",
+    "robloach/component-installer": "*"
+  },
+  "require-dev": {
     "components/bootstrap" : ">=2.3",
     "components/jquery": ">=1.9.0"
   }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+  "name": "aidanlister/jquery-stickytabs",
+  "type": "component",
+  "description": "This component extends bootstrap-tabs default behaviour to remember the selected tab across page reloads by using the location.hash. This also allows linking to a specific tab.",
+  "authors": [
+    {
+      "name": "Aidan Lister",
+      "email": "aidan@php.net",
+      "homepage": "http://aidanlister.com"
+    }
+  ],
+  "homepage": "http://aidanlister.com/2014/03/persisting-the-tab-state-in-bootstrap",
+  "keywords": [
+    "jQuery",
+    "Bootstrap"
+  ],
+  "license": "Public Domain",
+  "support": {
+    "source": "https://github.com/aidanlister/jquery-stickytabs"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "jquery.stickytabs.js"
+      ]
+    }
+  },
+  "require": {
+    "robloach/component-installer": "*",
+    "components/bootstrap" : ">=2.3",
+    "components/jquery": ">=1.9.0"
+  }
+}


### PR DESCRIPTION
It would be great to be able to install Chosen using the [Composer package manager](https://getcomposer.org). For Javascript sources that typically need to be installed in a 'public' folder exposed to the internet, this can be achieved using [ComponentInstaller](https://github.com/RobLoach/component-installer)
