### PR TITLE
Adding an option to use replaceState() method instead of pushState()

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ $(function() {
 |option|default|description|
 |------|-------|-----------|
 | selectorAttribute | false | Override the default `href` attribute used as selector when you need to activate multiple TabPanels at once with a single Tab using the `data-target` attribute. |
-| backToTop |false | Prevent the page from jumping down to the tab content by setting the backToTop setting to true. |
+| backToTop | false | Prevent the page from jumping down to the tab content by setting the backToTop setting to true. |
+| replaceState | false | Uses `replaceState()` method instead of `pushState()` to replace the current history entry. Causes the back button to always navigate to the previous page. |
 
 NuGet package
 =============

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -12,6 +12,7 @@
             getHashCallback: function(hash, btn) { return hash },
             selectorAttribute: "href",
             backToTop: false,
+            replaceState: false,
             initialTab: $('li.active > a', context)
         }, options );
 
@@ -23,10 +24,13 @@
           setTimeout(backToTop, 1);
         }
 
-        // We use pushState if it's available so the page won't jump, otherwise a shim.
+        // We use pushState (or replaceState) if it's available so the page won't jump, otherwise a shim.
         var changeHash = function(hash) {
-          if (history && history.pushState) {
-            history.pushState(null, null, window.location.pathname + window.location.search + '#' + hash);
+            if (history) {
+                var action = settings.replaceState ? history.replaceState : history.pushState;
+                if (action) {
+                    action(null, null, window.location.pathname + window.location.search + '#' + hash);
+                }
           } else {
             scrollV = document.body.scrollTop;
             scrollH = document.body.scrollLeft;


### PR DESCRIPTION
The excellent plugin uses [`pushState()`](https://developer.mozilla.org/en-US/docs/Web/API/History_API) in order to change the URL on every tab press, creating a deep link to the tab. This, however, causes every tab change to be added to navigation history.

This PR adds an option to use `replaceState()` method instead, so the URL is changed, but the history is not written, allowing the back button to go to the previous page.

This fixes #20.
