### PR TITLE
Show parent tabs if they exist (new option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $(function() {
 |------|-------|-----------|
 | selectorAttribute | false | Override the default `href` attribute used as selector when you need to activate multiple TabPanels at once with a single Tab using the `data-target` attribute. |
 | backToTop |false | Prevent the page from jumping down to the tab content by setting the backToTop setting to true. |
+| showParentTabs |false | Show the parent tabs so the selected tab comes into view if it is part of another tab grouping. |
 
 NuGet package
 =============

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-stickytabs",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "homepage": "https://github.com/aidanlister/jquery-stickytabs",
   "authors": [
     "Aidan Lister <aidan@aidanlister.com>"

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -21,11 +21,11 @@
           var hash = settings.selectorAttribute == "href" ? window.location.hash : window.location.hash.substring(1);
           if (hash != '') {
             var selector = hash ? 'a[' + settings.selectorAttribute +'="' + hash + '"]' : settings.initialTab;
-              if (settings.showParentTabs === true) {
-                showParentTabs(hash);
-              }
-              $(selector, context).tab('show');
-              setTimeout(backToTop, 1);
+            if (settings.showParentTabs === true) {
+              showParentTabs(hash);
+            }
+            $(selector, context).tab('show');
+            setTimeout(backToTop, 1);
           }
         }
 

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -2,7 +2,7 @@
  * jQuery Plugin: Sticky Tabs
  *
  * @author Aidan Lister <aidan@php.net>
- * @version 1.2.0
+ * @version 1.2.4
  */
 (function ( $ ) {
     $.fn.stickyTabs = function( options ) {
@@ -12,6 +12,7 @@
             getHashCallback: function(hash, btn) { return hash },
             selectorAttribute: "href",
             backToTop: false,
+            showParentTabs: false,
             initialTab: $('li.active > a', context)
         }, options );
 
@@ -19,9 +20,20 @@
         var showTabFromHash = function() {
           var hash = settings.selectorAttribute == "href" ? window.location.hash : window.location.hash.substring(1);
           if (hash != '') {
-              var selector = hash ? 'a[' + settings.selectorAttribute +'="' + hash + '"]' : settings.initialTab;
+            var selector = hash ? 'a[' + settings.selectorAttribute +'="' + hash + '"]' : settings.initialTab;
+              if (settings.showParentTabs === true) {
+                showParentTabs(hash);
+              }
               $(selector, context).tab('show');
               setTimeout(backToTop, 1);
+          }
+        }
+
+        var showParentTabs = function(hash) {
+          parent_hash = $('a[' + settings.selectorAttribute +'="' + hash + '"]').parents('.tab-pane').attr('id');
+          if (parent_hash !== undefined) {
+            $('a[' + settings.selectorAttribute +'="#' + parent_hash + '"]').tab('show');
+            showParentTabs('#' + parent_hash);
           }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-stickytabs",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "jquery-stickytabs =================",
   "main": "jquery.stickytabs.js",
   "directories": {


### PR DESCRIPTION
Issue - Showing the initial tab on load can be "hidden" as it is in a child tab group.

Based on a new setting as to not change current behaviour, this change locates parent tabs (using the .tab-pane class) and shows them before we show the requested tab from the url hash.
