### PR TITLE
Added option to change the show tab behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $(function() {
 |------|-------|-----------|
 | selectorAttribute | false | Override the default `href` attribute used as selector when you need to activate multiple TabPanels at once with a single Tab using the `data-target` attribute. |
 | backToTop |false | Prevent the page from jumping down to the tab content by setting the backToTop setting to true. |
+| showTabUsingClickTrigger |false | Activate the requeted tab using the click trigger so that any behaviours on the click trigger are activated. |
 
 NuGet package
 =============

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-stickytabs",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "homepage": "https://github.com/aidanlister/jquery-stickytabs",
   "authors": [
     "Aidan Lister <aidan@aidanlister.com>"

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -11,6 +11,7 @@
         var settings = $.extend({
             getHashCallback: function(hash, btn) { return hash },
             selectorAttribute: "href",
+            showTabUsingClickTrigger: false,
             backToTop: false,
             initialTab: $('li.active > a', context)
         }, options );
@@ -20,7 +21,11 @@
           var hash = settings.selectorAttribute == "href" ? window.location.hash : window.location.hash.substring(1);
           if (hash != '') {
               var selector = hash ? 'a[' + settings.selectorAttribute +'="' + hash + '"]' : settings.initialTab;
-              $(selector, context).tab('show');
+              if (settings.showTabUsingClickTrigger === true) {
+                $(selector, context).trigger('click');
+              } else {
+                $(selector, context).tab('show');
+              }
               setTimeout(backToTop, 1);
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-stickytabs",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "jquery-stickytabs =================",
   "main": "jquery.stickytabs.js",
   "directories": {


### PR DESCRIPTION
Issue - showing the tab doesn't trigger any applied behaviours.

Based on a new option as to not change current behaviour, this change changes from using a tab('show') to a trigger('click') which would then set off any behaviours that have been set against the click.
