### PR TITLE
Translate code to ES6, add support for named routes instead of selector

### DIFF
--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -6,43 +6,69 @@
  */
 (function ( $ ) {
     $.fn.stickyTabs = function( options ) {
-        var context = this
 
-        var settings = $.extend({
-            getHashCallback: function(hash, btn) { return hash },
+        let context  = this;
+        let settings = $.extend({
+            getHashCallback: (hash, btn) => hash,
             selectorAttribute: "href",
             backToTop: false,
             initialTab: $('li.active > a', context)
-        }, options );
+    }, options );
+
+        // Merge keys and values to object
+        let keysValuesToObject = function (keys, values) {
+            values = values || keys.map(function (v) { return true; });
+            let some;
+            keys.map(function (v) { return [v, this.shift()] }, values)
+                .map(function (v) { this[v[0]] = v[1]; }, some = {});
+            return some;
+        };
+
+        // Transpose keys and values on given object
+        let transposeObject = (object) => {
+            let keys   = Object.keys(object);
+            let values = Object.values(object);
+            return keysValuesToObject(values, keys);
+        };
+
+        // Get back from our custom route name to selector
+        let resolveSelector = (hash) => {
+            let realSelector;
+            hash = hash.split('#')[1];
+
+            // if there is route object given, get route name, else take hash as route name
+            realSelector = (settings.routeObject ? transposeObject(settings.routeObject)[hash] : hash);
+            return realSelector ? `a[${settings.selectorAttribute}='#${realSelector}']` : settings.initialTab;
+        };
 
         // Show the tab corresponding with the hash in the URL, or the first tab.
-        var showTabFromHash = function() {
-          var hash = settings.selectorAttribute == "href" ? window.location.hash : window.location.hash.substring(1);
-          if (hash != '') {
-              var selector = hash ? 'a[' + settings.selectorAttribute +'="' + hash + '"]' : settings.initialTab;
-              $(selector, context).tab('show');
-              setTimeout(backToTop, 1);
-          }
-        }
+        let showTabFromHash = () => {
+            let hash = settings.selectorAttribute == "href" ? window.location.hash : window.location.hash.substring(1);
+            if (hash !== '') {
+                let selector = resolveSelector(hash);
+                $(selector, context).tab('show');
+                setTimeout(backToTop, 1);
+            }
+        };
 
         // We use pushState if it's available so the page won't jump, otherwise a shim.
-        var changeHash = function(hash) {
-          if (history && history.pushState) {
-            history.pushState(null, null, window.location.pathname + window.location.search + '#' + hash);
-          } else {
-            scrollV = document.body.scrollTop;
-            scrollH = document.body.scrollLeft;
-            window.location.hash = hash;
-            document.body.scrollTop = scrollV;
-            document.body.scrollLeft = scrollH;
-          }
-        }
+        let changeHash = (hash) => {
+            if (history && history.pushState) {
+                history.pushState(null, null, window.location.pathname + window.location.search + '#' + hash);
+            } else {
+                scrollV = document.body.scrollTop;
+                scrollH = document.body.scrollLeft;
+                window.location.hash = hash;
+                document.body.scrollTop = scrollV;
+                document.body.scrollLeft = scrollH;
+            }
+        };
 
-        var backToTop = function() {
-          if (settings.backToTop === true) {
-            window.scrollTo(0, 0);
-          }
-        }
+        let backToTop = () => {
+            if (settings.backToTop === true) {
+                window.scrollTo(0, 0);
+            }
+        };
 
         // Set the correct tab when the page loads
         showTabFromHash();
@@ -52,12 +78,17 @@
 
         // Change the URL when tabs are clicked
         $('a', context).on('click', function(e) {
-          var hash = this.href.split('#')[1];
-          if (typeof hash != 'undefined' && hash != '') {
-              var adjustedhash = settings.getHashCallback(hash, this);
-              changeHash(adjustedhash);
-              setTimeout(backToTop, 1);
-          }
+            let hash = this.href.split('#')[1];
+
+            if (settings.routeObject) {
+                hash = settings.routeObject[hash];
+            }
+
+            if (typeof hash != 'undefined' && hash != '') {
+                let adjustedhash = settings.getHashCallback(hash, this);
+                changeHash(adjustedhash);
+                setTimeout(backToTop, 1);
+            }
         });
 
         return this;


### PR DESCRIPTION
In this pull request, I've added: 

1. Refactor ES6
2. Add support for named routes 

Example of usage: 

Sometimes, we need different name than just element ID, so let's define object like: 
```Javascript
let routes = {
   "nav-item1" : "this-is-item1-page",
   "nav-item2" : "this-is-item2-page",
   "nav-item3" : "this-is-item3-page",
};
```

So instead of `#nav-item1` we'll have `#this-is-item1-page` in URL. 

To enable this feature, you can just pass option named `routeObject`: 
```Javascript
$('.nav-tabs').stickyTabs({routeObject : routes});
```

If this option is not passed, default elements IDs will be used.